### PR TITLE
Remove showWebView method from WebViewContract

### DIFF
--- a/Sources/core-web-browser/WebView/WebViewContract.swift
+++ b/Sources/core-web-browser/WebView/WebViewContract.swift
@@ -4,7 +4,6 @@ public protocol WebViewContract {
     func registerRule(name: String, content: String, whitelist: [String])
     func applyRule(name: String)
     func removeAllRules()
-    func showWebView()
     func load(_ url: URL)
     func didTapBackButton()
     func didTapForwardButton()

--- a/Sources/core-web-browser/WebView/WebViewProxy.swift
+++ b/Sources/core-web-browser/WebView/WebViewProxy.swift
@@ -43,10 +43,6 @@ public final class WebViewProxy: NSObject, WebViewContract {
         self.webView.configuration.userContentController.removeAllContentRuleLists()
     }
 
-    public func showWebView() {
-        webView.isHidden = false
-    }
-
     public func load(_ url: URL) {
         webView.load(URLRequest(url: url))
     }

--- a/Sources/core-web-browser/Window/WindowViewAdapter.swift
+++ b/Sources/core-web-browser/Window/WindowViewAdapter.swift
@@ -8,7 +8,6 @@ public final class WindowViewAdapter: WindowViewContract {
     }
 
     public func didRequestSearch(_ text: String) {
-        webView.showWebView()
         webView.load(SearchURLBuilder.makeURL(from: text))
     }
 

--- a/Tests/core-web-browserTests/TestHelpers/WebViewSpy.swift
+++ b/Tests/core-web-browserTests/TestHelpers/WebViewSpy.swift
@@ -6,7 +6,6 @@ class WebViewSpy: WebViewContract {
         case registerRule(_ name: String, _ content: String, _ whitelist: [String] = [])
         case applyRule(_ name: String)
         case removeAllRules
-        case showWebView
         case load(url: URL)
         case didTapBackButton
         case didTapForwardButton
@@ -26,10 +25,6 @@ class WebViewSpy: WebViewContract {
 
     func removeAllRules() {
         receivedMessages.append(.removeAllRules)
-    }
-
-    func showWebView() {
-        receivedMessages.append(.showWebView)
     }
 
     func load(_ url: URL) {

--- a/Tests/core-web-browserTests/WebView/WebViewProxyTests.swift
+++ b/Tests/core-web-browserTests/WebView/WebViewProxyTests.swift
@@ -17,18 +17,8 @@ class WebViewProxyTests: XCTestCase {
         XCTAssertEqual(webView.registeredObservers, ["URL", "canGoBack", "canGoForward", "estimatedProgress"])
     }
 
-    func test_showWebView_makeWebViewVisible() {
-        let (sut, webView, _, _) = makeSUT()
-        webView.isHidden = true
-
-        sut.showWebView()
-
-        XCTAssertFalse(webView.isHidden)
-    }
-
     func test_sendText_sendsCorrectRequest() {
-        let (sut, webView, _, _) = makeSUT()
-        webView.isHidden = true
+        let (sut, webView, _, _) = makeSUT()        
 
         sut.load(URL(string: "https://openai.com")!)
 

--- a/Tests/core-web-browserTests/Window/WindowViewAdapterTests.swift
+++ b/Tests/core-web-browserTests/Window/WindowViewAdapterTests.swift
@@ -8,7 +8,7 @@ class WindowViewAdapterTests: XCTestCase {
 
         sut.didRequestSearch("www.apple.com")
 
-        XCTAssertEqual(webView.receivedMessages, [.showWebView, .load(url: URL(string: "http://www.apple.com")!)])
+        XCTAssertEqual(webView.receivedMessages, [.load(url: URL(string: "http://www.apple.com")!)])
         XCTAssertEqual(presenter.receivedMessages, [])
     }
 


### PR DESCRIPTION
Issue: #12 

Remove the `WebViewContract` method from the core-web-browser module since its usage does not affect the user experience. Also, it is not the responsibility of WebViewProxy to hide/show view components.
